### PR TITLE
WIP: Use the node transport

### DIFF
--- a/plugin/index.js
+++ b/plugin/index.js
@@ -11,7 +11,7 @@ global.crypto = crypto;
 
 // The ES modules we'll need to import
 let MeshDevice;
-let TransportHTTP;
+let TransportNode;
 let create;
 let toBinary;
 let Protobuf;
@@ -132,10 +132,10 @@ module.exports = (app) => {
   import('@meshtastic/core')
     .then((lib) => {
       MeshDevice = lib.MeshDevice;
-      return import('@meshtastic/transport-http');
+      return import('@meshtastic/transport-node');
     })
     .then((lib) => {
-      TransportHTTP = lib.TransportHTTP;
+      TransportNode = lib.TransportNode;
       return import('@bufbuild/protobuf');
     })
     .then((lib) => {
@@ -152,7 +152,7 @@ module.exports = (app) => {
     });
 
   plugin.start = (settings) => {
-    if (!TransportHTTP) {
+    if (!TransportNode) {
       app.setPluginStatus('Waiting for Meshtastic library to load');
       setTimeout(() => {
         plugin.start(settings);
@@ -272,7 +272,7 @@ module.exports = (app) => {
             nodes[nodeNum].seen = new Date(nodeDbData[nodeNum].seen);
           });
         app.setPluginStatus(`Connecting to Meshtastic node ${settings.device.address}`);
-        return TransportHTTP.create(settings.device.address);
+        return TransportNode.create(settings.device.address);
       })
       .then((transport) => {
         device = new MeshDevice(transport);


### PR DESCRIPTION
We're currently using the HTTP transport which has some reliability issues, likely due to https://github.com/nodejs/undici/issues/1135.

This PR switches to the Node transport from https://github.com/meshtastic/web/pull/703. Not mergeable until that is available in a release (either on JSR, or preferably NPM).